### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/cryptorats23/1ceaeea6-e77e-469d-b5d9-3f4b6e296ea5/0f4ba19e-aeef-406b-b3af-4f929a95327f/_apis/work/boardbadge/fd6d0328-69e5-403d-9dfe-964cce66e038)](https://dev.azure.com/cryptorats23/1ceaeea6-e77e-469d-b5d9-3f4b6e296ea5/_boards/board/t/0f4ba19e-aeef-406b-b3af-4f929a95327f/Microsoft.RequirementCategory)
 # Blockchain API library (Python, v1)
 
 An official Python module for interacting with the Blockchain.info API. Compatible with both Python 2 and Python 3.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#3](https://dev.azure.com/cryptorats23/1ceaeea6-e77e-469d-b5d9-3f4b6e296ea5/_workitems/edit/3). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.